### PR TITLE
fix(recherche): renomme Formation en Course dans le CourseNormalizer

### DIFF
--- a/src/Infrastructure/Search/Normalizer/CourseNormalizer.php
+++ b/src/Infrastructure/Search/Normalizer/CourseNormalizer.php
@@ -16,7 +16,7 @@ class CourseNormalizer implements ContextAwareNormalizerInterface
     public function normalize($object, string $format = null, array $context = [])
     {
         if (!$object instanceof Course) {
-            throw new \InvalidArgumentException('Unexpected type for normalization, expected Formation, got ' . get_class($object));
+            throw new \InvalidArgumentException('Unexpected type for normalization, expected Course, got ' . get_class($object));
         }
         $title = $object->getTitle();
         $formation = $object->getFormation();


### PR DESCRIPTION
Un petit detail de nommage aperçu lors de la lecture en replay du live.