### PR TITLE
fix schema validate sur make seed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ seed: vendor/autoload.php ## Génère des données dans la base de données (doc
 	$(sy) hautelook:fixtures:load -q
 
 .PHONY: migrate
-migrate: vendor/autoload.php ## Migre la base de donnée (docker-compose up doit être lancé)
+migrate: vendor/autoload.php ## Migre la base de données (docker-compose up doit être lancé)
 	$(sy) doctrine:migrations:migrate -q
 
 .PHONY: rollback
@@ -57,6 +57,7 @@ import: vendor/autoload.php ## Import les données du site actuel
 
 .PHONY: test
 test: vendor/autoload.php ## Execute les tests
+	$(drtest) phptest bin/console doctrine:schema:validate --skip-sync
 	$(drtest) phptest vendor/bin/phpunit
 	$(dr) --no-deps node yarn run test
 

--- a/src/Domain/Forum/Entity/Topic.php
+++ b/src/Domain/Forum/Entity/Topic.php
@@ -63,7 +63,7 @@ class Topic
     private Collection $tags;
 
     /**
-     * @ORM\ManyToOne(targetEntity="App\Domain\Auth\User", inversedBy="topics")
+     * @ORM\ManyToOne(targetEntity="App\Domain\Auth\User")
      * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
      */
     private User $author;


### PR DESCRIPTION
Fix le schema qui n'est pas valide et bloquant lors d'un `make seed`.

Ajout du schema:validate dans la CI via `Test`