### PR TITLE
Avoir le backtrace de chaque requête en env de dev

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -1,6 +1,7 @@
 doctrine:
     dbal:
         url: '%env(resolve:DATABASE_URL)%'
+        profiling_collect_backtrace: '%kernel.debug%'
 
         # IMPORTANT: You MUST configure your server version,
         # either here or in the DATABASE_URL env var (see .env file)


### PR DESCRIPTION
Mieux qu'une explication, voici une image : https://user-images.githubusercontent.com/4582866/56085914-24d56100-5e4c-11e9-994b-c9ad273ca8c3.png
=> Rajoute " Show query backtrace " dans l'environnement de dév.