### PR TITLE
fix: variable d'environnement manquante

### DIFF
--- a/.env
+++ b/.env
@@ -43,6 +43,11 @@ GOOGLE_CLIENT_SECRET=
 ADMIN_PREFIX=/admin
 ###< google/apiclient ###
 
+PAYPAL_ID=
+PAYPAL_SECRET=
+STRIPE_PUBLIC=
+STRIPE_SECRET=
+
 ###> nelmio/cors-bundle ###
 CORS_ALLOW_ORIGIN=^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$
 ###< nelmio/cors-bundle ###


### PR DESCRIPTION
Lorsque l'on fait un `make seed` il y a 3 erreurs car il manque les variables d'environnement qui ne sont pas dans le fichier