### PR TITLE
fix(config): .preload.php autogenerated file ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /public/icons
 /public/old
 /public/uploads
+/src/.preload.php
 *.sql
 
 # Assets


### PR DESCRIPTION
Bonjour,

Je pense qu'il faut aussi modifier _Grafikart.fr/tools/docker/php/Dockerfile_ pour utiliser le **OPCache Preloading** et améliorer les perfs (quand le site sera en PROD).

une modif de ce genre :

```
RUN echo "opcache.preload=/path/to/project/src/.preload.php" > "/usr/local/etc/php/conf.d/docker-php-ext-opcache.ini"
```