### PR TITLE
fix: edition of comment for guest user and not owner or admin of it

### DIFF
--- a/assets/components/Comments.jsx
+++ b/assets/components/Comments.jsx
@@ -194,7 +194,9 @@ const Comment = memo(({ comment, editing, onEdit, onUpdate, onDelete, onReply, c
 
   function handleEdit (e) {
     e.preventDefault()
-    onEdit(comment)
+    if (isAuthenticated() && canEdit) {
+      onEdit(comment)
+    }
   }
 
   async function handleUpdate (e) {

--- a/assets/components/Comments.jsx
+++ b/assets/components/Comments.jsx
@@ -194,7 +194,7 @@ const Comment = memo(({ comment, editing, onEdit, onUpdate, onDelete, onReply, c
 
   function handleEdit (e) {
     e.preventDefault()
-    if (isAuthenticated() && canEdit) {
+    if (canEdit) {
       onEdit(comment)
     }
   }


### PR DESCRIPTION
Ajout de condition pour que le formulaire d'édition d'un commentaire ne s'affiche que si l'auteur ou un admin doubleClick dessus.