### PR TITLE
fix: force reload nginx to load site before trying letsencrypt

### DIFF
--- a/tools/ansible/nginx/tasks/letsencrypt.yml
+++ b/tools/ansible/nginx/tasks/letsencrypt.yml
@@ -5,6 +5,8 @@
     cmd: |
       sed -i -r 's/(listen .*443)/\1;#/g; s/(ssl_(certificate|certificate_key|trusted_certificate) )/#;#\1/g' /etc/nginx/sites-available/{{domain}}
     creates: "/etc/letsencrypt/live/{{ domain }}/fullchain.pem"
+- name: Nginx | Force reload to activate letsencrypt site
+  service: name=nginx state=restarted
 - name: Nginx | LetsEncrypt certbot certificate
   shell:
     cmd: "certbot certonly --webroot -d {{ domain }} --email contact@{{ domain }} -w /var/www/_letsencrypt -n --agree-tos --force-renewal"


### PR DESCRIPTION
La fonction d'Ansible de "notify" une action permet de prévoir une action en fin d'execution du playbook/block. Pour résoudre le problème de chargement des sites nginx avant d'exécuter la génération de certificat let's encrypt, c'est de forcer le reload/restart d'nginx.
