### PR TITLE
Fix : Bouton social

### DIFF
--- a/assets/css/modules/_btn.scss
+++ b/assets/css/modules/_btn.scss
@@ -236,6 +236,7 @@
   display: block;
   padding: 12px 16px;
   border-radius: 3px;
+  position: relative;
 
   .icon {
     position: absolute;


### PR DESCRIPTION
Ajout d'une position relative pour fixer l'icône social svg sur Safari

<img width="375" alt="bug-position" src="https://user-images.githubusercontent.com/6663426/103444319-ac3db600-4c67-11eb-9b6a-ccd15f515b58.png">
