### PR TITLE
Fixes #260 Api platform endpoint & Fix Twitter feed in footer

### DIFF
--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -17,3 +17,5 @@ api_platform:
     pagination:
       client_items_per_page: false
       items_per_page_parameter_name: count
+
+  enable_entrypoint: false

--- a/src/Core/Services/TwitterService.php
+++ b/src/Core/Services/TwitterService.php
@@ -27,7 +27,7 @@ class TwitterService
             $token = $this->getBearerToken();
             $response = $this->http->request(
                 'GET',
-                'https://api.twitter.com/1.1/statuses/user_timeline.json',
+                'https://api.twitter.com/1.1/statuses/user_timeline.json?exclude_replies=true',
                 [
                     'headers' => [
                         'authorization' => "Bearer $token",


### PR DESCRIPTION
- Modification de la config Api Platform pour ne pas rendre accessible les endpoints de l'API à l'adresse /api 

- Fix du twitter footer pour enlever les tweets qui sont des réponses  (pour avoir le meme fonctionnement que le site actuel)
