### PR TITLE
fix: responsive home (home-push__mosaic live parts).

### DIFF
--- a/assets/css/pages/_home.scss
+++ b/assets/css/pages/_home.scss
@@ -259,6 +259,9 @@
     bottom: 0;
     transform: translateY(50%);
   }
+  .home-push__mosaic > *:last-child {
+    width: 300px;
+  }
 }
 
 @include up(1400) {
@@ -366,9 +369,6 @@
   .home-post__image img {
     width: 100%;
     height: auto;
-  }
-  .home-push__mosaic > *:last-child {
-    width: 300px;
   }
 }
 


### PR DESCRIPTION
La partie "live" de la mosaic sur la homepage reste de largeur "fixe" alors que les autres sont "fluide".
Juste un petit bout de code qui n'est pas a la bonne place.