### PR TITLE
fix: correction de marge dans le footer (derniers tweets)

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -50,7 +50,9 @@
     </div>
 
     <div>
-      <a class="footer-title" href="https://twitter.com/grafikart_fr">Mes derniers tweets</a>
+      <div class="footer-title">
+        <a href="https://twitter.com/grafikart_fr">Mes derniers tweets</a>
+      </div>
       <div class="footer-tweets">
         {% for tweet in last_tweets() %}
           <div class="footer-tweet">


### PR DESCRIPTION
Suite à l'ajout du lien vers le compte twitter, la marge a disparu et les titres du footer ne sont plus alignés :

Avant : 
![image](https://user-images.githubusercontent.com/36472830/106368531-6d744c00-634a-11eb-9792-c9ed6b0631dc.png)

Après : 
![image](https://user-images.githubusercontent.com/36472830/106368544-87ae2a00-634a-11eb-84c1-4c350a84cbec.png)

