### PR TITLE
FIX: named route "cursus_show" does not exist.

### DIFF
--- a/src/Http/Controller/Course/CursusController.php
+++ b/src/Http/Controller/Course/CursusController.php
@@ -21,7 +21,7 @@ class CursusController extends AbstractController
     }
 
     /**
-     * Route("/cursus/{slug<[a-z0-9\-]+>}", name="cursus_show").
+     * @Route("/cursus/{slug<[a-z0-9\-]+>}", name="cursus_show").
      */
     public function show(Cursus $cursus): Response
     {


### PR DESCRIPTION
Visiting Home Page throws this error `the named route "cursus_show" as such route does not exist`

![Screenshot_2021-02-06 An exception has been thrown during the rendering of a template ( Unable to generate a URL for the na](https://user-images.githubusercontent.com/4411670/107107528-d1f34780-6831-11eb-9ca3-a0d12cdffb3f.png)
