### PR TITLE
Fix #344: on video end, check success modal appears only once

### DIFF
--- a/assets/elements/courses/ProgressTracker.js
+++ b/assets/elements/courses/ProgressTracker.js
@@ -52,7 +52,10 @@ export class ProgressTracker extends HTMLElement {
   async onEnd () {
     await wait(300)
     const { message } = await jsonFetch(`/api/progress/${this.contentId}/1000`, { method: 'POST' }).catch(console.error)
-    document.body.appendChild(strToDom(message))
+    // on vérifie que la vidéo n'a pas déjà été finie
+    if (document.getElementsByTagName('modal-dialog').length === 0) {
+      document.body.appendChild(strToDom(message))
+    }
     confetti({
       particleCount: 100,
       zIndex: 3000,


### PR DESCRIPTION
Empeche le modal  de fin de vidéo "Bien joué jeune padawan " de réapparaitre si l'utilisateur recule dans la vidéo et la finit une 2ème fois sans rafraîchir la page.