### PR TITLE
fix: tris dans la page historique

### DIFF
--- a/src/Http/Controller/Account/HistoryController.php
+++ b/src/Http/Controller/Account/HistoryController.php
@@ -36,6 +36,8 @@ class HistoryController extends AbstractController
                 ->setParameter('progress', Progress::TOTAL);
         }
 
+        $query = $query->orderBy('p.createdAt', 'DESC');
+        
         $progress = $paginator->paginate(
             $query->setMaxResults(16)->getQuery()
         );


### PR DESCRIPTION
- Changement de l'ordre de tris dans la page historique afin que les derniers tutos visionnés apparaissent en premier (issue #354)