### PR TITLE
feat: page d'erreur 405

### DIFF
--- a/templates/bundles/TwigBundle/Exception/error405.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error405.html.twig
@@ -1,0 +1,4 @@
+{% extends 'bundles/TwigBundle/Exception/layout.html.twig' %}
+
+{% block title 'Méthode non autorisée' %}
+{% block description "Vous essayez de faire quoi, là ?" %}


### PR DESCRIPTION
Si on essaye d'accéder à (par exemple) cette page : https://grafikart.fr/api/badges/lochness/unlock, ça nous renvoie une 405.