### PR TITLE
fix: image PHPStorm cliquable

### DIFF
--- a/templates/pages/env.html.twig
+++ b/templates/pages/env.html.twig
@@ -35,7 +35,9 @@
         </nav-tabs>
         <div style="position:relative;">
           <div class="stack-large" id="phpstorm">
-            <img src="{{ asset('images/env/phpstorm.jpg') }}" alt="Interface PHPStorm" class="card-big">
+            <a href="{{ asset('images/env/phpstorm.jpg') }}" target="_blank">
+              <img src="{{ asset('images/env/phpstorm.jpg') }}" alt="Interface PHPStorm" class="card-big">
+            </a>
             <div class="formatted container-narrow">
               <p>
                 Dans la plupart des vidéos j'utilise l'éditeur <a


### PR DESCRIPTION
L'image de l'environnement de VSCode est cliquable mais pas celle de PHPStorm (https://grafikart.fr/a-propos#phpstorm)