### PR TITLE
fix(mailing): Twig block typo in mailing macros

### DIFF
--- a/templates/mails/macros.twig
+++ b/templates/mails/macros.twig
@@ -46,15 +46,15 @@
 {%- endmacro -%}
 
 {%- macro section(content) -%}
-  {%~ if format == 'html' -%}
-<table class="subcopy" width="100%" cellpadding="0" cellspacing="0" role="presentation">
-  <tr>
-    <td>
-      {{- content | raw -}}
-    </td>
-  </tr>
-</table>
-  {%~ else -%}
+  {%- if format == 'html' -%}
+    <table class="subcopy" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+      <tr>
+        <td>
+          {{- content | raw -}}
+        </td>
+      </tr>
+    </table>
+  {%- else -%}
     {{~ content ~}}
-  {%- endif ~%}
+  {%- endif -%}
 {%- endmacro -%}


### PR DESCRIPTION
utilisation de "-" au lieu de "~"