### PR TITLE
fix(oauth): normalize correct id key for facebook and google oauth user

### DIFF
--- a/src/Infrastructure/Social/Normalizer/FacebookNormalizer.php
+++ b/src/Infrastructure/Social/Normalizer/FacebookNormalizer.php
@@ -14,7 +14,7 @@ class FacebookNormalizer extends Normalizer
     {
         return [
             'email' => $object->getEmail(),
-            'github_id' => $object->getId(),
+            'facebook_id' => $object->getId(),
             'type' => 'Facebook',
             'username' => $object->getName(),
         ];

--- a/src/Infrastructure/Social/Normalizer/GoogleNormalizer.php
+++ b/src/Infrastructure/Social/Normalizer/GoogleNormalizer.php
@@ -14,7 +14,7 @@ class GoogleNormalizer extends Normalizer
     {
         return [
             'email' => $object->getEmail(),
-            'github_id' => $object->getId(),
+            'google_id' => $object->getId(),
             'type' => 'Google',
             'username' => $object->getName(),
         ];


### PR DESCRIPTION
utilisation de la bonne clé lors de la normalisation d'un FacebookUser ou GoogleUser afin d'éviter une mauvaise hydratation lors de la création d'un User avec Oauth

https://github.com/Grafikart/Grafikart.fr/blob/550b120373b9393c28a861df176a5819862461b1/src/Infrastructure/Social/SocialLoginService.php#L30-L44