### PR TITLE
Ajouter le path de revision.target pour l'URL sur le titre pour chaque révisions acceptés

### DIFF
--- a/templates/account/_revisions.html.twig
+++ b/templates/account/_revisions.html.twig
@@ -17,7 +17,9 @@
             {{ revision.target.title }}
           </a>
         {% else %}
-          {{ revision.target.title }}
+          <a href="{{ path(revision.target) }}">
+            {{ revision.target.title }}
+          </a>
         {% endif %}
       </td>
       <td width="150" class="mobile-hidden">


### PR DESCRIPTION
Avant la modification : 

![image](https://user-images.githubusercontent.com/14293805/159474290-dc5e5fb4-3715-4fd3-a941-fdb7a4093099.png)

Après la modification : 
![image](https://user-images.githubusercontent.com/14293805/159474529-7055c5b0-38e6-407a-92e1-5b69c4e1c316.png)


Le lien renvoie sur la page de l'article et non de la révision.