### PR TITLE
Remplacer pluriel par singulier pour tutoriel

### DIFF
--- a/templates/courses/index.html.twig
+++ b/templates/courses/index.html.twig
@@ -65,7 +65,7 @@
 
     {% else %}
       <div class="text-center">
-        <h1 class="hero-title mb1">Aucun <strong>tutoriels</strong> :(</h1>
+        <h1 class="hero-title mb1">Aucun <strong>tutoriel</strong> :(</h1>
         <p class="text-big">
           Aucun contenu ne correspond aux filtres que vous avez sélectionnés.
         </p>


### PR DESCRIPTION
Supprimer le s pour tutoriels car pas nécessaire.
En lien avec --> https://github.com/Grafikart/Grafikart.fr/issues/450