### PR TITLE
fix #457 : use Grafikart instead of 'noreply' as email sender name

### DIFF
--- a/src/Infrastructure/Mailing/Mailer.php
+++ b/src/Infrastructure/Mailing/Mailer.php
@@ -4,6 +4,7 @@ namespace App\Infrastructure\Mailing;
 
 use App\Infrastructure\Queue\EnqueueMethod;
 use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Crypto\DkimSigner;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Message;
@@ -27,7 +28,7 @@ class Mailer
         $text = $this->twig->render($template, array_merge($data, ['layout' => 'mails/base.text.twig']));
 
         return (new Email())
-            ->from('noreply@grafikart.fr')
+            ->from(new Address('noreply@grafikart.fr', 'Grafikart'))
             ->html($html)
             ->text($text);
     }


### PR DESCRIPTION
Actuellement quand on reçoit un mail de Grafikart on a comme nom d'expéditeur "noreply" et si on ne lit pas le sujet le mail peut être facile ignoré ou confondu avec les autres "noreply" mais aussi a beaucoup de chance de se retrouver dans les spams.