### PR TITLE
Feat(Command): Replace commands return's magic numbers with Command consts

### DIFF
--- a/src/Command/CleanCommand.php
+++ b/src/Command/CleanCommand.php
@@ -36,7 +36,7 @@ class CleanCommand extends Command
         $this->clean($io, EmailVerification::class, 'demandes de changement d\'email');
         $this->clean($io, PasswordResetToken::class, 'demandes de reset de mdp');
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function cleanUsers(SymfonyStyle $io): void

--- a/src/Command/DumpCommand.php
+++ b/src/Command/DumpCommand.php
@@ -40,7 +40,7 @@ class DumpCommand extends Command
             $io->error("Impossible d'exporter la base de données");
             $io->error($process->getErrorOutput());
 
-            return 1;
+            return Command::FAILURE;
         }
 
         // On sauvegarde le fichier dans notre backup storage
@@ -61,6 +61,6 @@ class DumpCommand extends Command
         unlink($dumpFile.'.gz');
         $io->success('La base de donnée a bien été sauvegardée');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/IndexCommand.php
+++ b/src/Command/IndexCommand.php
@@ -48,6 +48,6 @@ class IndexCommand extends Command
         $io->progressFinish();
         $io->success('Les contenus ont bien été indexés');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/SeedCommand.php
+++ b/src/Command/SeedCommand.php
@@ -31,7 +31,7 @@ class SeedCommand extends Command
         $command = $this->getApplication()->find('hautelook:fixtures:load');
         $return = $command->run($input, $output);
 
-        if (0 !== $return) {
+        if (Command::SUCCESS !== $return) {
             return $return;
         }
 
@@ -79,6 +79,6 @@ class SeedCommand extends Command
         }
         $this->em->flush();
 
-        return 0;
+        return Command::SUCCESS;
     }
 }


### PR DESCRIPTION
Replacing magic numbers with `Symfony Command` constants helps improve code readability and maintainability 