### PR TITLE
fix(profil): afficher le pseudo dans le titre

### DIFF
--- a/templates/user/profil.html.twig
+++ b/templates/user/profil.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title 'Mon compte' %}
+{% block title user.username %}
 
 {% set bodyClass = 'header-light' %}
 


### PR DESCRIPTION
Quand on est sur le profil d'un utilisateur le titre affiche "Mon compte" alors qu'il devrait afficher le pseudo.

![image](https://user-images.githubusercontent.com/8747883/210188295-005a31f0-d06b-4156-a63b-3d59c989bedb.png)