### PR TITLE
#472 show podcasts instead of podcasts suggestions on home page

### DIFF
--- a/fixtures/fixtures.yaml
+++ b/fixtures/fixtures.yaml
@@ -7,9 +7,6 @@ App\Domain\Auth\User:
     username: Grafikart
     email: grafikart@grafikart.fr
 
-App\Domain\Live\Live:
-  live{1..10} (extends live):
-
 App\Domain\Course\Entity\Course:
   course{1..100} (extends course):
 
@@ -72,6 +69,7 @@ App\Domain\Premium\Entity\Plan:
 App\Domain\Podcast\Entity\Podcast:
   podcast{1..20} (extends podcast):
     title: 'Podcast publié <current()>'
+    youtube: 'https://www.youtube.com/watch?v=zEJF1SnfxX8'
   podcast_future{1..3} (extends podcast):
     title: 'Podcast programmé <current()>'
     scheduledAt: <dateTimeBetween('+1 week', '+1 month')>

--- a/src/Domain/Podcast/Repository/PodcastRepository.php
+++ b/src/Domain/Podcast/Repository/PodcastRepository.php
@@ -3,7 +3,6 @@
 namespace App\Domain\Podcast\Repository;
 
 use App\Domain\Auth\User;
-use App\Domain\Blog\Post;
 use App\Domain\Podcast\Entity\Podcast;
 use App\Infrastructure\Orm\AbstractRepository;
 use App\Infrastructure\Orm\IterableQueryBuilder;
@@ -24,12 +23,17 @@ class PodcastRepository extends AbstractRepository
     /**
     * @return IterableQueryBuilder<Podcast>
     */
-    public function findRecent(int $limit): IterableQueryBuilder
+    public function findRecent(int $limit, bool $published = false): IterableQueryBuilder
     {
-        return $this->createIterableQuery('p')
+        $qb = $this->createIterableQuery('p')
             ->select('p')
-            ->where('p.createdAt < NOW()')
-            ->orderBy('p.createdAt', 'DESC')
+            ->where('p.createdAt < NOW()');
+
+        if ($published) {
+            $qb->andWhere('(p.youtube IS NOT NULL OR p.mp3 IS NOT NULL)');
+        }
+
+        return $qb->orderBy('p.createdAt', 'DESC')
             ->setMaxResults($limit);
     }
 

--- a/src/Http/Controller/HomeController.php
+++ b/src/Http/Controller/HomeController.php
@@ -37,7 +37,7 @@ class HomeController extends AbstractController
             'hours' => round($courseRepository->findTotalDuration() / 3600),
             'formations' => $this->em->getRepository(Formation::class)->findRecent(3),
             'cursus' => $this->em->getRepository(Cursus::class)->findRecent(5),
-            'podcasts' => $this->em->getRepository(Podcast::class)->findRecent(3),
+            'podcasts' => $this->em->getRepository(Podcast::class)->findRecent(3, true),
             'posts' => $this->em->getRepository(Post::class)->findRecent(5),
         ]);
     }


### PR DESCRIPTION
rajout d'un filtre **published** pour faire la différence entre podcast et suggestion de podcast lors la récupération des dernières entrées sur la home page

# améliorations
l'idéal serait d'avoir deux entités :  Podcast et PodcastSuggestion, ansi un Podcast pourrait être créé sur base d'une suggestion ou pas