### PR TITLE
[Security] Prevent possible user enumeration in authentication mechanism #483

### DIFF
--- a/src/Domain/Auth/Authenticator.php
+++ b/src/Domain/Auth/Authenticator.php
@@ -11,6 +11,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
@@ -77,6 +78,11 @@ class Authenticator extends AbstractLoginFormAuthenticator
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
     {
+        if ($exception instanceof BadCredentialsException &&
+            $exception->getPrevious() instanceof UserNotFoundException) {
+            return parent::onAuthenticationFailure($request, $exception);
+        }
+
         $user = $this->lastPassport?->getUser();
         if ($user instanceof User &&
             $exception instanceof BadCredentialsException


### PR DESCRIPTION
Comme précisé dans #483 ce patch a pour but de corriger la faille de sécurité relative à l'affiche du message d'erreur quand un utilisateur n'existe pas sur le site

pour éviter une possible user enumeration comme expliqué ici : https://symfony.com/blog/cve-2021-21424-prevent-user-enumeration-in-authentication-mechanisms