### PR TITLE
Add circle clip-path animation on theme switch

### DIFF
--- a/assets/css/modules/_themeswitcher.scss
+++ b/assets/css/modules/_themeswitcher.scss
@@ -1,3 +1,9 @@
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
 .theme-switcher {
   display: inline-block;
 

--- a/assets/elements/ThemeSwitcher.js
+++ b/assets/elements/ThemeSwitcher.js
@@ -19,8 +19,46 @@ export class ThemeSwitcher extends HTMLElement {
     input.addEventListener('change', e => {
       const themeToRemove = e.currentTarget.checked ? 'light' : 'dark'
       const themeToAdd = e.currentTarget.checked ? 'dark' : 'light'
-      document.body.classList.add(`theme-${themeToAdd}`)
-      document.body.classList.remove(`theme-${themeToRemove}`)
+
+      const applyTheme = () => {
+        document.body.classList.add(`theme-${themeToAdd}`)
+        document.body.classList.remove(`theme-${themeToRemove}`)
+      }
+
+      if (
+        !document.startViewTransition ||
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      ) {
+        applyTheme()
+      } else {
+        const { top, left, width, height } = e.currentTarget.getBoundingClientRect()
+        const x = left + width / 2
+        const y = top + height / 2
+        const right = window.innerWidth - x
+        const bottom = window.innerHeight - y
+        const radius = Math.hypot(Math.max(x, right), Math.max(y, bottom))
+
+        const transition = document.startViewTransition(() => {
+          applyTheme()
+        })
+
+        transition.ready.then(() => {
+          document.documentElement.animate(
+            {
+              clipPath: [
+                `circle(0px at ${x}px ${y}px)`,
+                `circle(${radius}px at ${x}px ${y}px)`
+              ]
+            },
+            {
+              duration: 500,
+              easing: 'ease-in-out',
+              pseudoElement: '::view-transition-new(root)'
+            }
+          )
+        })
+      }
+
       if (!isAuthenticated()) {
         cookie('theme', themeToAdd, { expires: 7 })
       } else {


### PR DESCRIPTION
Ahoy @Grafikart 👋

Merci pour le tuto https://grafikart.fr/tutoriels/theme-switcher-circle-2315 🙂
Et quoi de mieux que le site Grafikart.fr lui-même pour le tester ?

Cette PR ajoute l'animation circulaire au changement de thème via la View Transitions API + clip-path, avec fallback pour les navigateurs non compatibles et respect de prefers-reduced-motion.