### PR TITLE
fix: respecter l'utilitaire de largeur passé à <x-atoms.button>

### DIFF
--- a/resources/views/components/atoms/button.blade.php
+++ b/resources/views/components/atoms/button.blade.php
@@ -1,8 +1,11 @@
-@props(['variant' => 'primary', 'size' => 'md', 'href' => null, 'as' => 'button'])
+@props(['variant' => 'primary', 'size' => 'md', 'href' => null, 'as' => 'button', 'class' => null])
 
 @php
+    $hasWidthUtility = $class !== null && preg_match('/(^|\s)(w-|min-w-|max-w-)/', $class) === 1;
+
     $cls = [
-        'rounded-sm [&_svg]:size-4 flex justify-center items-center gap-3 transition-all w-max font-semibold ',
+        'rounded-sm [&_svg]:size-4 flex justify-center items-center gap-3 transition-all font-semibold',
+        'w-max' => ! $hasWidthUtility,
         // Variants
         'bg-primary text-primary-foreground hover:brightness-120 shadow-button ' => $variant === 'primary',
         'border hover:bg-border/30 bg-background font-medium' => $variant === 'secondary',
@@ -16,6 +19,7 @@
         'p-2 rounded-full' => $size === 'icon',
         // Offset the icon a bit for better alignment
         '[&_svg:first-child]:-ml-0.5 [&_svg:last-child]:-mr-0.5' => $size !== 'icon',
+        $class,
     ];
 @endphp
 


### PR DESCRIPTION
Refs #509 (partie « boutons »).

## Problème

Sur la nouvelle version, les boutons de tous les formulaires d'authentification s'affichent en largeur intrinsèque (alignés à gauche, taille du texte) au lieu de la pleine largeur des champs auxquels ils sont censés s'aligner :

- `auth/login.blade.php` → `<x-atoms.button class="w-full">`
- `auth/register.blade.php` → idem
- `auth/forgot-password.blade.php`, `auth/reset-password.blade.php`, `auth/confirm-password.blade.php` → idem
- `auth/2fa-challenge.blade.php` → idem (×2)
- `pages/premium.blade.php` (CTA de la dialog) → idem

La cause est dans `resources/views/components/atoms/button.blade.php` : la chaîne de classes de base contient `w-max` en dur. Quand un caller passe `class="w-full"`, `$attributes->class()` concatène simplement les deux classes sans dédupliquer ; comme `w-max` et `w-full` ont la même spécificité CSS, l'ordre dans la feuille compilée tranche, et `w-max` l'emporte.

C'est cohérent avec ce qui a été noté sur #509 : le `w-full` est bien présent côté caller, mais l'ordre des règles le rend inopérant.

## Solution

Une seule modification sur `resources/views/components/atoms/button.blade.php` :

1. `class` devient un prop déclaré (`@props([..., 'class' => null])`) — pattern déjà utilisé par `atoms/card` et conforme à la convention décrite dans `CLAUDE.md`.
2. `w-max` n'est ajouté à la liste que si le caller ne passe pas d'utilitaire de largeur (regex sur `w-`, `min-w-`, `max-w-`). En cas de conflit potentiel, `w-max` est simplement omis — pas de bataille de spécificité, pas besoin d'un `tailwind-merge` côté PHP.
3. `$class` est ajouté en fin de tableau pour que la classe passée par le caller continue d'être rendue (Laravel retire `class` de `$attributes` dès qu'il devient un prop).

```diff
-@props(['variant' => 'primary', 'size' => 'md', 'href' => null, 'as' => 'button'])
+@props(['variant' => 'primary', 'size' => 'md', 'href' => null, 'as' => 'button', 'class' => null])

 @php
+    $hasWidthUtility = $class !== null && preg_match('/(^|\s)(w-|min-w-|max-w-)/', $class) === 1;
+
     $cls = [
-        'rounded-sm [&_svg]:size-4 flex justify-center items-center gap-3 transition-all w-max font-semibold ',
+        'rounded-sm [&_svg]:size-4 flex justify-center items-center gap-3 transition-all font-semibold',
+        'w-max' => ! $hasWidthUtility,
         // ...
+        $class,
     ];
 @endphp
```

## Notes

- **Aucun call-site n'est touché.** Les ~25 usages qui ne passent pas de classe gardent strictement le comportement actuel (`w-max`). Les usages qui passent `class="w-full"` se mettent à fonctionner. Les usages qui passent autre chose (`ml-auto`, `mt-4`, …) ne sont pas affectés non plus.
- Volontairement non inclus : les contournements `w-full!` / `bg-[#444]!` dans `auth/oauth.blade.php` et `auth/verify-email.blade.php`. Ils continuent de fonctionner et pourront être nettoyés dans un PR de suivi (le retrait du `!` sur `bg-[#444]` mérite une vérification visuelle dédiée).
- Volontairement non couvert ici : la partie « thème PayPal » et le délai d'affichage du bouton PayPal mentionnés dans #509 — la première a été confirmée comme volontaire en commentaire, la seconde relève du SDK PayPal et sort du périmètre.
- Sur les variants responsifs (`sm:w-full`, etc.), la regex ne matche pas — c'est intentionnel : à la taille de base on garde `w-max`, et le variant prend la main au breakpoint demandé.

## Vérification

- Visuel : `/connexion`, `/inscription`, `/mot-de-passe-oublie`, `/reinitialiser-mot-de-passe`, `/confirmer-mot-de-passe`, `/2fa-challenge`, dialog premium → bouton submit en pleine largeur, alignement cohérent avec les champs.
- Non-régression : page `/ui` (galerie de boutons sans `class`) et boutons `class="ml-auto"` de `/users/edit` rendent toujours en `w-max`.
